### PR TITLE
allow other types of messages (e.g. INFO)

### DIFF
--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -134,7 +134,8 @@ module IsItWorking
         messages = []
         statuses.each do |status|
           status.messages.each do |m|
-            messages << "#{m.ok? ? 'OK:  ' : 'FAIL:'} #{status.name} - #{m.message} (#{status.time ? sprintf('%0.000f', status.time * 1000) : '?'}ms)"
+
+            messages << "#{sprintf '%-5s', m.state.to_s.upcase}: #{status.name} - #{m.message} (#{status.time ? sprintf('%0.000f', status.time * 1000) : '?'}ms)"
           end
         end
         

--- a/lib/is_it_working/status.rb
+++ b/lib/is_it_working/status.rb
@@ -6,15 +6,23 @@ module IsItWorking
     # This class is used to contain individual status messages. Eache method can represent either
     # and +ok+ message or a +fail+ message.
     class Message
-      attr_reader :message
+      class <<self
+        attr_accessor :ok_states
+      end
 
-      def initialize(message, ok)
+      self.ok_states = [:ok, :info]
+
+      attr_reader :message
+      attr_reader :state
+
+
+      def initialize(message, state)
         @message = message
-        @ok = ok
+        @state = state
       end
 
       def ok?
-        @ok
+        self.class.ok_states.include? state
       end
     end
 
@@ -34,12 +42,16 @@ module IsItWorking
 
     # Add a message indicating that the check passed.
     def ok(message)
-      @messages << Message.new(message, true)
+      @messages << Message.new(message, :ok)
+    end
+
+    def info(message)
+      @messages << Message.new(message, :info)
     end
 
     # Add a message indicating that the check failed.
     def fail(message)
-      @messages << Message.new(message, false)
+      @messages << Message.new(message, :fail)
     end
 
     # Returns +true+ only if all checks were OK.

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -13,15 +13,25 @@ describe IsItWorking::Status do
     status.should_not be_success
     status.messages.size.should == 1
     status.messages.first.should_not be_ok
+    status.messages.first.state.should == :fail
     status.messages.first.message.should == "boom"
   end
   
   it "should have successes" do
     status.ok("wow")
     status.should be_success
+    status.messages.first.state.should == :ok
     status.messages.size.should == 1
     status.messages.first.should be_ok
     status.messages.first.message.should == "wow"
+  end
+
+  it "should have successes and infos" do
+    status.ok("wow")
+    status.info("fyi")
+    status.should be_success
+    status.messages.each { |x| x.should be_ok }
+    status.messages.last.state.should == :info
   end
   
   it "should have both errors and successes" do


### PR DESCRIPTION
This patch adds support for an "INFO" message type, in addition to OK and FAIL. While I've refactored Message to (presumably) support additional types, only INFO is explicitly enabled. I'm happy to make it more extensible, but wanted to start a dialogue first.
