### PR TITLE
Add timing awareness to Is It Working

### DIFF
--- a/is_it_working.gemspec
+++ b/is_it_working.gemspec
@@ -20,10 +20,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'activerecord', '>= 3.2', '< 4.3'
 
   spec.add_development_dependency 'dalli', '>= 0'
-  spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'sqlite3', '~> 1.3.0'
+
+  spec.add_development_dependency 'pry'
 
   spec.add_development_dependency 'rspec'    , '~> 2.99.0'
-  spec.add_development_dependency 'webmock'  , '~> 1.7.7'
+  spec.add_development_dependency 'webmock'  , '~> 2.3.1'
   spec.add_development_dependency 'bundler'  , '~> 1.7'
   spec.add_development_dependency 'rake'     , '~> 10.0'
   spec.add_development_dependency 'appraisal', '~> 2.0'

--- a/lib/is_it_working/checks/ping_check.rb
+++ b/lib/is_it_working/checks/ping_check.rb
@@ -28,7 +28,7 @@ module IsItWorking
       @timeout = options[:timeout] || 2
       @alias = options[:alias] || @host
     end
-    
+
     def call(status)
       begin
         ping(@host, @port)
@@ -41,9 +41,9 @@ module IsItWorking
         status.fail("#{@alias} did not respond on port #{@port.inspect} within #{@timeout} seconds")
       end
     end
-    
+
     def ping(host, port)
-      timeout(@timeout) do
+      Timeout.timeout(@timeout) do
         s = TCPSocket.new(host, port)
         s.close
       end

--- a/lib/is_it_working/filter.rb
+++ b/lib/is_it_working/filter.rb
@@ -4,28 +4,30 @@ module IsItWorking
     class AsyncRunner < Thread
       attr_accessor :filter_status
     end
-    
+
     class SyncRunner
       attr_accessor :filter_status
-      
+
       def initialize
         yield
       end
-      
+
       def join
       end
     end
-    
-    attr_reader :name, :async
-    
+
+    attr_reader :name, :async, :warn_timeout, :timeout
+
     # Create a new filter to run a status check. The name is used for display purposes.
-    def initialize(name, check, async = true)
+    def initialize(name, check, async = true, options = {})
       @name = name
       @check = check
       @async = async
+      @warn_timeout = options[:warn_timeout] || Float::INFINITY
+      @timeout = options[:timeout] || Float::INFINITY
     end
-    
-    # Run a status the status check. This method keeps track of the time it took to run
+
+    # Run a status check. This method keeps track of the time it took to run
     # the check and will trap any unexpected exceptions and report them as failures.
     def run
       status = Status.new(name)
@@ -37,19 +39,43 @@ module IsItWorking
           status.fail("#{name} error: #{e.inspect}")
         end
         status.time = Time.now - t
+        handle_timing! status
       end
       runner.filter_status = status
       runner
     end
-    
+
     class << self
       # Run a list of filters and return their status objects
-      def run_filters (filters)
+      def run_filters(filters)
         runners = filters.collect{|f| f.run}
         statuses = runners.collect{|runner| runner.filter_status}
         runners.each{|runner| runner.join}
         statuses
       end
+    end
+
+    private
+
+    def handle_timing!(status)
+      if fail_timeout_exceeded?(status.time)
+        status.fail("runtime exceeded critical threshold: #{timeout}ms")
+      elsif warn_timeout_exceeded?(status.time)
+        status.warn("runtime exceeded warning threshold: #{warn_timeout}ms")
+      end
+    end
+
+    def warn_timeout_exceeded?(time)
+      timeout_exceeded? time, warn_timeout
+    end
+
+    def fail_timeout_exceeded?(time)
+      timeout_exceeded? time, timeout
+    end
+
+    def timeout_exceeded?(time, val)
+      # binding.pry if time == nil
+      time * 1000 > val
     end
   end
 end

--- a/lib/is_it_working/handler.rb
+++ b/lib/is_it_working/handler.rb
@@ -95,7 +95,7 @@ module IsItWorking
         end
       end
 
-      @filters << Filter.new(name, check, options[:async])
+      @filters << Filter.new(name, check, options[:async], options)
     end
 
     # Helper method to synchronize a block of code so it can be thread safe.

--- a/lib/is_it_working/status.rb
+++ b/lib/is_it_working/status.rb
@@ -4,17 +4,24 @@ module IsItWorking
   # considered a success if all messages are ok.
   class Status
     # This class is used to contain individual status messages. Eache method can represent either
-    # and +ok+ message or a +fail+ message.
+    # an +ok+ message or a +fail+ message.
     class Message
-      attr_reader :message
+      RESULTS = [:ok, :warn, :fail].freeze
+      attr_reader :message, :result
 
-      def initialize(message, ok)
+      def initialize(message, result)
+        raise ArgumentError, "Result #{result} is not recognized!" unless RESULTS.include?(result)
+
         @message = message
-        @ok = ok
+        @result = result
       end
 
       def ok?
-        @ok
+        RESULTS[0..1].include?(result)
+      end
+
+      def warn?
+        result == :warn
       end
     end
 
@@ -34,17 +41,27 @@ module IsItWorking
 
     # Add a message indicating that the check passed.
     def ok(message)
-      @messages << Message.new(message, true)
+      @messages << Message.new(message, :ok)
+    end
+
+    # Add a message indicating that the check is tolerable but not ok.
+    def warn(message)
+      @messages << Message.new(message, :warn)
     end
 
     # Add a message indicating that the check failed.
     def fail(message)
-      @messages << Message.new(message, false)
+      @messages << Message.new(message, :fail)
     end
 
     # Returns +true+ only if all checks were OK.
     def success?
       @messages.all?{|m| m.ok?}
+    end
+
+    # Returns +true+ if all checks were OK but warnings were present.
+    def warnings?
+      success? && @messages.any?{|m| m.warn?}
     end
   end
 end

--- a/spec/active_record_check_spec.rb
+++ b/spec/active_record_check_spec.rb
@@ -9,7 +9,7 @@ describe IsItWorking::ActiveRecordCheck do
 
   class IsItWorking::TestActiveRecord < ActiveRecord::Base
   end
-  
+
   it "succeeds if the ActiveRecord connection is active" do
     abstract_conn.stub(active?: true)
     ActiveRecord::Base.stub(connection: abstract_conn)
@@ -18,7 +18,7 @@ describe IsItWorking::ActiveRecordCheck do
     expect(status).to be_success
     expect(status.messages.first.message).to eq "ActiveRecord::Base.connection is active"
   end
-  
+
   it "allows specifying the class to check the connection for" do
     abstract_conn.stub(active?: true)
     IsItWorking::TestActiveRecord.stub(connection: abstract_conn)

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -1,17 +1,17 @@
 require File.expand_path('../spec_helper', __FILE__)
 
 describe IsItWorking::Filter do
-  
+
   it "should have a name" do
     filter = IsItWorking::Filter.new(:test, lambda{})
     filter.name.should == :test
   end
-  
+
   it "should run a check and return a thread" do
     check = lambda do |status|
       status.ok("success")
     end
-    
+
     filter = IsItWorking::Filter.new(:test, check)
     runner = filter.run
     status = runner.filter_status
@@ -20,12 +20,12 @@ describe IsItWorking::Filter do
     status.messages.first.message.should == "success"
     status.time.should_not be_nil
   end
-  
-  it "should run a check and recue an errors" do
+
+  it "should run a check and rescue an error" do
     check = lambda do |status|
       raise "boom!"
     end
-    
+
     filter = IsItWorking::Filter.new(:test, check)
     runner = filter.run
     status = runner.filter_status
@@ -34,7 +34,13 @@ describe IsItWorking::Filter do
     status.messages.first.message.should include("boom")
     status.time.should_not be_nil
   end
-  
+
+  it "should have a warn state when exceeding the warn_threshold" do
+  end
+
+  it "should have a warn state when exceeding the warn_threshold" do
+  end
+
   it "should run multiple filters and return their statuses" do
     filter_1 = IsItWorking::Filter.new(:test, lambda{|status| status.ok("OK")})
     filter_2 = IsItWorking::Filter.new(:test, lambda{|status| status.fail("FAIL")})
@@ -42,5 +48,5 @@ describe IsItWorking::Filter do
     statuses.first.should be_success
     statuses.last.should_not be_success
   end
-  
+
 end

--- a/spec/handler_spec.rb
+++ b/spec/handler_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe IsItWorking::Handler do
-  
+
   it "should lookup filters from the pre-defined checks" do
     handler = IsItWorking::Handler.new do |h|
       h.check :directory, :path => ".", :permissions => :read
@@ -11,7 +11,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("directory")
   end
-  
+
   it "should use blocks as filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -23,7 +23,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("block - Okey dokey")
   end
-  
+
   it "should use object as filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :lambda, lambda{|status| status.ok("A-okay")}
@@ -33,7 +33,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("lambda - A-okay")
   end
-  
+
   it "should create asynchronous filters by default" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -44,7 +44,7 @@ describe IsItWorking::Handler do
     IsItWorking::Filter::AsyncRunner.should_receive(:new).and_return(runner)
     response = handler.call({})
   end
-  
+
   it "should be able to create synchronous filters" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block, :async => false do |status|
@@ -55,7 +55,7 @@ describe IsItWorking::Handler do
     IsItWorking::Filter::SyncRunner.should_receive(:new).and_return(runner)
     response = handler.call({})
   end
-  
+
   it "should work with synchronous checks" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block, :async => false do |status|
@@ -67,7 +67,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("OK")
     response.last.flatten.join("").should include("block - Okey dokey")
   end
-  
+
   it "should return a success response if all checks pass" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -82,7 +82,7 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("block - success")
     response.last.flatten.join("").should include("block - worked")
   end
-  
+
   it "should return an error response if any check fails" do
     handler = IsItWorking::Handler.new do |h|
       h.check :block do |status|
@@ -97,7 +97,33 @@ describe IsItWorking::Handler do
     response.last.flatten.join("").should include("block - success")
     response.last.flatten.join("").should include("block - down")
   end
-  
+
+  it "should return a warning status if a check exceeds a warning timeout" do
+    handler = IsItWorking::Handler.new do |h|
+      h.check :block, warn_timeout: 900 do |status|
+        sleep 1
+        status.ok('That took a while! 😅')
+      end
+    end
+    response = handler.call({})
+    response.first.should == 203
+    response.last.flatten.join.should include("OK: block - That took a while")
+    response.last.flatten.join.should include("WARN: block - runtime exceeded warning threshold")
+  end
+
+    it "should return a failure status if a check exceeds a warning timeout and a timeout" do
+    handler = IsItWorking::Handler.new do |h|
+      h.check :block,  warn_timeout: 500, timeout: 900 do |status|
+        sleep 1
+        status.ok('That took a while! 😅')
+      end
+    end
+    response = handler.call({})
+    response.first.should == 500
+    response.last.flatten.join.should include("OK: block - That took a while")
+    response.last.flatten.join.should include("FAIL: block - runtime exceeded critical threshold")
+  end
+
   it "should be able to be used in a middleware stack with the route /is_it_working" do
     app_response = [200, {"Content-Type" => "text/plain"}, ["OK"]]
     app = lambda{|env| app_response}
@@ -105,13 +131,13 @@ describe IsItWorking::Handler do
     stack = IsItWorking::Handler.new(app) do |h|
       h.check(:test){|status| check_called = true; status.ok("Woot!")}
     end
-    
+
     stack.call("PATH_INFO" => "/").should == app_response
     check_called.should == false
     stack.call("PATH_INFO" => "/is_it_working").last.flatten.join("").should include("Woot!")
     check_called.should == true
   end
-  
+
   it "should be able to be used in a middleware stack with a custom route" do
     app_response = [200, {"Content-Type" => "text/plain"}, ["OK"]]
     app = lambda{|env| app_response}
@@ -119,19 +145,19 @@ describe IsItWorking::Handler do
     stack = IsItWorking::Handler.new(app, "/woot") do |h|
       h.check(:test){|status| check_called = true; status.ok("Woot!")}
     end
-    
+
     stack.call("PATH_INFO" => "/is_it_working").should == app_response
     check_called.should == false
     stack.call("PATH_INFO" => "/woot").last.flatten.join("").should include("Woot!")
     check_called.should == true
   end
-  
+
   it "should be able to synchronize access to a block" do
     handler = IsItWorking::Handler.new
     handler.synchronize{1}.should == 1
     handler.synchronize{2}.should == 2
   end
-  
+
   it "should be able to set the host name reported in the output" do
     handler = IsItWorking::Handler.new
     handler.hostname = "woot"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+require 'pry'
+
 begin
   require 'simplecov'
   SimpleCov.start do

--- a/spec/status_spec.rb
+++ b/spec/status_spec.rb
@@ -1,13 +1,13 @@
 require File.expand_path('../spec_helper', __FILE__)
 
 describe IsItWorking::Status do
-  
+
   let(:status){ IsItWorking::Status.new(:test) }
-  
+
   it "should have a name" do
     status.name.should == :test
   end
-  
+
   it "should have errors" do
     status.fail("boom")
     status.should_not be_success
@@ -15,7 +15,7 @@ describe IsItWorking::Status do
     status.messages.first.should_not be_ok
     status.messages.first.message.should == "boom"
   end
-  
+
   it "should have successes" do
     status.ok("wow")
     status.should be_success
@@ -23,7 +23,17 @@ describe IsItWorking::Status do
     status.messages.first.should be_ok
     status.messages.first.message.should == "wow"
   end
-  
+
+  it "should have warnings" do
+    status.warn("uh oh")
+    status.should be_success
+    status.should be_warnings
+    status.messages.size.should == 1
+    status.messages.first.should be_ok
+    status.messages.first.should be_warn
+    status.messages.first.message.should == "uh oh"
+  end
+
   it "should have both errors and successes" do
     status.fail("boom")
     status.ok("wow")
@@ -34,11 +44,11 @@ describe IsItWorking::Status do
     status.messages.last.should be_ok
     status.messages.last.message.should == "wow"
   end
-  
+
   it "should have a time" do
     status.time.should == nil
     status.time = 0.1
     status.time.should == 0.1
   end
-  
+
 end

--- a/spec/url_check_spec.rb
+++ b/spec/url_check_spec.rb
@@ -58,7 +58,9 @@ describe IsItWorking::UrlCheck do
   end
 
   it "should send basic authentication" do
-    stub_request(:get, "user:passwd@example.com/test?a=1").to_return(:status => [200, "Success"])
+    stub_request(:get, "http://example.com/test?a=1")
+      .with(headers: { authorization: 'Basic dXNlcjpwYXNzd2Q=' })
+      .to_return(:status => [200, "Success"])
     check = IsItWorking::UrlCheck.new(:get => "http://example.com/test?a=1", :username => "user", :password => "passwd")
     check.call(status)
     status.should be_success
@@ -134,7 +136,7 @@ describe IsItWorking::UrlCheck do
     Net::HTTP.should_receive(:new).with('localhost', 80).and_return(http)
     request = Net::HTTP::Get.new("/test?a=1")
     Net::HTTP::Get.should_receive(:new).with("/test?a=1", {}).and_return(request)
-    http.should_receive(:start).and_raise(TimeoutError)
+    http.should_receive(:start).and_raise(Timeout::Error)
 
     check = IsItWorking::UrlCheck.new(:get => "http://localhost/test?a=1", :open_timeout => 1, :read_timeout => 2)
     check.call(status)


### PR DESCRIPTION
Checks can now be defined with `timeout` and `warn_timeout` params in milliseconds, and report warn or fail if they are exceeded:

![image](https://user-images.githubusercontent.com/72645/65262168-b91cb180-dad7-11e9-84a9-6a7c96cfd4fd.png)
